### PR TITLE
hawkular-metrics

### DIFF
--- a/roles/openshift_metrics/tasks/cleanup.yaml
+++ b/roles/openshift_metrics/tasks/cleanup.yaml
@@ -3,7 +3,7 @@
   command: >
     {{ openshift.common.client_binary }} -n '{{ project }}'
     delete --selector=metrics-infra
-    services,replicationcontrollers,serviceaccounts,secrets
+    services,replicationcontrollers,serviceaccounts,secrets,templates
   register: ret
   changed_when: "ret.stdout != 'No resources found'"
 - name: test cluster-reader permissions for the heapster service account

--- a/roles/openshift_metrics/tasks/generate_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_certificates.yaml
@@ -36,14 +36,24 @@
     get 'secret/{{ sa_secret.stdout }}'
     --template '{{ '{{index .data "ca.crt"}}' }}'
   register: sa_secret
+- name: read files for the heapster secret
+  command: base64 --wrap 0 "{{ mktemp.stdout }}/certs/heapster.{{ file }}"
+  register: heapster_secret
+  with_items:
+  - cert
+  - key
+  loop_control:
+    loop_var: file
 - name: generate heapster secret template
   template:
-    src: heapster_secrets.j2
+    src: secret.j2
     dest: "{{ mktemp.stdout }}/templates/heapster_secrets.yaml"
   vars:
-    cert: >
-      {{ lookup('file', '{{ mktemp.stdout }}/certs/heapster.cert')|b64encode }}
-    key: >
-      {{ lookup('file', '{{ mktemp.stdout }}/certs/heapster.key')|b64encode }}
-    client_ca: "{{ sa_secret.stdout }}"
-    allowed_users: "{{ 'system:master-proxy'|b64encode }}"
+    name: heapster-secrets
+    labels:
+      metrics-infra: heapster
+    data:
+      heapster.cert: "{{ heapster_secret.results[0].stdout }}"
+      heapster.key: "{{ heapster_secret.results[1].stdout }}"
+      heapster.client-ca: "{{ sa_secret.stdout }}"
+      heapster.allowed-users: "{{ 'system:master-proxy'|b64encode }}"

--- a/roles/openshift_metrics/tasks/generate_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_certificates.yaml
@@ -57,3 +57,165 @@
       heapster.key: "{{ heapster_secret.results[1].stdout }}"
       heapster.client-ca: "{{ sa_secret.stdout }}"
       heapster.allowed-users: "{{ 'system:master-proxy'|b64encode }}"
+- name: generate hawkular-metrics certificates
+  include: setup_certificate.yaml
+  vars:
+    component: hawkular-metrics
+    hostnames: "hawkular-metrics,{{ hawkular_metrics_hostname }}"
+- name: generate hawkular-cassandra certificates
+  include: setup_certificate.yaml
+  vars:
+    component: hawkular-cassandra
+    hostnames: hawkular-cassandra
+# TODO keytool as dependency?  move key/trust store generation to containers?
+- name: import the hawkular metrics cert into the cassandra truststore
+  shell: >
+    keytool -noprompt -import -v -trustcacerts
+    -alias hawkular-metrics
+    -file '{{ mktemp.stdout|quote }}/certs/hawkular-metrics.cert'
+    -keystore '{{ mktemp.stdout|quote }}/certs/hawkular-cassandra.truststore'
+    -storepass
+    "$(< "{{ mktemp.stdout|quote }}/certs/hawkular-cassandra-truststore.pwd")"
+- name: import the hawkular cassandra cert into the hawkular metrics truststore
+  shell: >
+    keytool -noprompt -import -v -trustcacerts
+    -alias hawkular-cassandra
+    -file '{{ mktemp.stdout }}/certs/hawkular-cassandra.cert'
+    -keystore '{{ mktemp.stdout }}/certs/hawkular-metrics.truststore'
+    -storepass
+    "$(< "{{ mktemp.stdout|quote }}/certs/hawkular-metrics-truststore.pwd")"
+- name: import the hawkular cassandra cert into the cassandra truststore
+  shell: >
+    keytool -noprompt -import -v -trustcacerts
+    -alias hawkular-cassandra
+    -file '{{ mktemp.stdout }}/certs/hawkular-cassandra.cert'
+    -keystore '{{ mktemp.stdout }}/certs/hawkular-cassandra.truststore'
+    -storepass
+    "$(< "{{ mktemp.stdout|quote }}/certs/hawkular-cassandra-truststore.pwd")"
+- name: import the ca certificate into the cassandra truststore
+  shell: >
+    keytool -noprompt -import -v -trustcacerts
+    -alias '{{ item }}'
+    -file '{{ mktemp.stdout }}/certs/ca.crt'
+    -keystore '{{ mktemp.stdout }}/certs/hawkular-cassandra.truststore'
+    -storepass
+    "$(< "{{ mktemp.stdout|quote }}/certs/hawkular-cassandra-truststore.pwd")"
+  with_items:
+  - ca
+  - metricca
+  - cassandraca
+- name: import the ca certificate into the hawkular metrics truststore
+  shell: >
+    keytool -noprompt -import -v -trustcacerts
+    -alias '{{ item }}'
+    -file '{{ mktemp.stdout }}/certs/ca.crt'
+    -keystore '{{ mktemp.stdout }}/certs/hawkular-metrics.truststore'
+    -storepass
+    "$(< "{{ mktemp.stdout|quote }}/certs/hawkular-metrics-truststore.pwd")"
+  with_items:
+  - ca
+  - metricca
+  - cassandraca
+- name: generate password for htpasswd file for hawkular metrics
+  shell: cat /dev/urandom | tr -dc _A-Z-a-z-0-9 | head -c15
+  register: hawkular_metrics_password
+- name: generate htpasswd file for hawkular metrics
+  shell: >
+    htpasswd -cb
+    "{{ mktemp.stdout|quote }}/certs/hawkular-metrics.htpasswd" hawkular
+    '{{ hawkular_metrics_password.stdout }}'
+- name: read files for the hawkular-metrics secret
+  command: >
+    base64 --wrap 0 "{{ mktemp.stdout }}/certs/{{ file }}"
+  register: hawkular_metrics_secret
+  with_items:
+  - hawkular-metrics.keystore
+  - hawkular-metrics-keystore.pwd
+  - hawkular-metrics.truststore
+  - hawkular-metrics-truststore.pwd
+  - hawkular-metrics.htpasswd
+  - hawkular-metrics.cert
+  - ca.crt
+  - hawkular-cassandra.keystore
+  - hawkular-cassandra-keystore.pwd
+  - hawkular-cassandra.truststore
+  - hawkular-cassandra-truststore.pwd
+  - hawkular-cassandra.pem
+  - hawkular-cassandra.cert
+  loop_control:
+    loop_var: file
+- name: generate hawkular-metrics-secrets secret template
+  template:
+    src: secret.j2
+    dest: "{{ mktemp.stdout }}/templates/hawkular_metrics_secrets.yaml"
+  vars:
+    name: hawkular-metrics-secrets
+    labels:
+      metrics-infra: hawkular-metrics
+    data:
+      hawkular-metrics.keystore: >
+        "{{ hawkular_metrics_secret.results[0].stdout }}"
+      hawkular-metrics.keystore.password: >
+        "{{ hawkular_metrics_secret.results[1].stdout }}"
+      hawkular-metrics.truststore: >
+        "{{ hawkular_metrics_secret.results[2].stdout }}"
+      hawkular-metrics.truststore.password: >
+        "{{ hawkular_metrics_secret.results[3].stdout }}"
+      hawkular-metrics.keystore.alias: "{{ 'hawkular-metrics'|b64encode }}"
+      hawkular-metrics.htpasswd.file: >
+        "{{ hawkular_metrics_secret.results[4].stdout }}"
+- name: generate hawkular-metrics-certificate secret template
+  template:
+    src: secret.j2
+    dest: "{{ mktemp.stdout }}/templates/hawkular_metrics_certificate.yaml"
+  vars:
+    name: hawkular-metrics-certificate
+    labels:
+      metrics-infra: hawkular-metrics
+    data:
+      hawkular-metrics.certificate: >
+        "{{ hawkular_metrics_secret.results[5].stdout }}"
+      hawkular-metrics-ca.certificate: >
+        "{{ hawkular_metrics_secret.results[6].stdout }}"
+- name: generate hawkular-metrics-account secret template
+  template:
+    src: secret.j2
+    dest: "{{ mktemp.stdout }}/templates/hawkular_metrics_account.yaml"
+  vars:
+    name: hawkular-metrics-account
+    labels:
+      metrics-infra: hawkular-metrics
+    data:
+      hawkular-metrics.username: "{{ 'hawkular'|b64encode }}"
+      hawkular-metrics.password: >
+        "{{ hawkular_metrics_password.stdout|b64encode }}"
+- name: generate cassandra secret template
+  template:
+    src: secret.j2
+    dest: "{{ mktemp.stdout }}/templates/cassandra_secrets.yaml"
+  vars:
+    name: hawkular-cassandra-secrets
+    labels:
+      metrics-infra: hawkular-cassandra
+    data:
+      cassandra.keystore: "{{ hawkular_metrics_secret.results[7].stdout }}"
+      cassandra.keystore.password: >
+        {{ hawkular_metrics_secret.results[8].stdout }}
+      cassandra.keystore.alias: "{{ 'hawkular-cassandra'|b64encode }}"
+      cassandra.truststore: "{{ hawkular_metrics_secret.results[9].stdout }}"
+      cassandra.truststore.password: >
+        {{ hawkular_metrics_secret.results[10].stdout }}
+      cassandra.pem: "{{ hawkular_metrics_secret.results[10].stdout }}"
+- name: generate cassandra-certificate secret template
+  template:
+    src: secret.j2
+    dest: "{{ mktemp.stdout }}/templates/cassandra_certificate.yaml"
+  vars:
+    name: hawkular-cassandra-certificate
+    labels:
+      metrics-infra: hawkular-cassandra
+    data:
+      cassandra.certificate: >
+        {{ hawkular_metrics_secret.results[11].stdout }}
+      cassandra-ca.certificate: >
+        {{ hawkular_metrics_secret.results[7].stdout }}

--- a/roles/openshift_metrics/tasks/install_hawkular.yaml
+++ b/roles/openshift_metrics/tasks/install_hawkular.yaml
@@ -2,3 +2,76 @@
 - name: Generate hawkular replication controller
   #template: src=hawkular.j2 dest={{mktemp.stdout}}/templates/metrics-hawkular-rc.yaml
   template: src=hawkular.j2 dest={{out_dir}}/templates/metrics-hawkular-rc.yaml
+# TODO import templates to this repo?
+- name: create templates
+  command: >
+    {{ openshift.common.client_binary }} -n '{{ project }}'
+    create -f '{{ origin_metrics_dir }}/deployer/templates/{{ item }}.yaml'
+  with_items:
+  - hawkular-metrics
+  - hawkular-cassandra
+  - hawkular-cassandra-node-pv
+  - hawkular-cassandra-node-dynamic-pv
+  - hawkular-cassandra-node-emptydir
+  - support
+- name: create hawkular metrics objects
+  command: >
+    {{ openshift.common.client_binary }} -n '{{ project }}'
+    create -f '{{ mktemp.stdout }}/templates/{{ file }}'
+  with_items:
+  - hawkular_metrics_secrets.yaml
+  - hawkular_metrics_certificate.yaml
+  - hawkular_metrics_account.yaml
+  - cassandra_secrets.yaml
+  - cassandra_certificate.yaml
+  loop_control:
+    loop_var: file
+- name: process other templates
+  shell: >
+    {{ openshift.common.client_binary }} -n '{{ project }}'
+    process '{{ file }}'
+    | oc create -f -
+  with_items:
+  - hawkular-cassandra-services
+  - hawkular-support
+  loop_control:
+    loop_var: file
+# TODO persistent storage
+- name: process hawkular-metrics template
+  shell: >
+    {{ openshift.common.client_binary }} -n '{{ project }}'
+    process hawkular-metrics
+    --value 'IMAGE_PREFIX={{ image_prefix }}'
+    --value 'IMAGE_VERSION={{ image_version }}'
+    --value 'METRIC_DURATION={{ metrics_duration }}'
+    --value 'MASTER_URL={{ master_url }}'
+    --value 'USER_WRITE_ACCESS={{ hawkular_user_write_access }}'
+    --value 'USE_PERSISTENT_STORAGE=false'
+    | oc create -f -
+- name: process cassandra template for the master node
+  shell: >
+    {{ openshift.common.client_binary }} -n '{{ project }}'
+    process hawkular-cassandra-node-emptydir
+    --value 'IMAGE_PREFIX={{ image_prefix }}'
+    --value 'IMAGE_VERSION={{ image_version }}'
+    --value NODE=1
+    --value MASTER=true
+    | oc create -f -
+## TODO multi-node cassandra
+#- name: process cassandra template for other nodes
+#  shell: >
+#    {{ openshift.common.client_binary }} -n '{{ project }}'
+#    process hawkular-cassandra-node-emptydir
+#    --value 'IMAGE_PREFIX={{ image_prefix }}'
+#    --value 'IMAGE_VERSION={{ image_version }}'
+#    --value NODE={{ item }}
+#    | oc create -f -
+#  with_sequence: start=1 end={{ cassandra_nodes }}
+#  when: {{ cassandra_nodes > 1 }}
+- name: create the hawkular-metrics route
+  command: >
+    {{ openshift.common.client_binary }} -n '{{ project }}'
+    create route reencrypt hawkular-metrics
+    --hostname='{{ hawkular_metrics_hostname }}'
+    --service=hawkular-metrics
+    --dest-ca-cert='{{ mktemp.stdout }}/certs/ca.crt'

--- a/roles/openshift_metrics/tasks/main.yaml
+++ b/roles/openshift_metrics/tasks/main.yaml
@@ -1,6 +1,13 @@
 ---
+# TODO import templates to this repo?
+- name: temporary hack to include templates from origin-metrics
+  fail: msg='the origin_metrics_dir variable is required'
+  when: "{{ origin_metrics_dir is not defined }}"
+- name: check that hawkular_metrics_hostname is set
+  fail: msg='the hawkular_metrics_hostname variable is required'
+  when: "{{ hawkular_metrics_hostname is not defined }}"
 - name: Install Metrics
-  include: "{{ role_path }}/tasks/install_{{ item }}.yaml"
+  include: "{{ role_path }}/tasks/install_{{ include_file }}.yaml"
   vars:
     template_dir: ../openshift_logging/templates
     out_dir: /home/vagrant
@@ -8,3 +15,6 @@
     - metrics
     - heapster
     - hawkular
+  loop_control:
+    loop_var: include_file
+# TODO configure metricsPublicURL and restart master?

--- a/roles/openshift_metrics/tasks/setup_certificate.yaml
+++ b/roles/openshift_metrics/tasks/setup_certificate.yaml
@@ -1,0 +1,50 @@
+---
+- name: generate {{ component }} keys
+  command: >
+    {{ openshift.common.admin_binary }} ca create-server-cert
+    --key='{{ mktemp.stdout }}/certs/{{ component }}.key'
+    --cert='{{ mktemp.stdout }}/certs/{{ component }}.crt'
+    --hostnames='{{ hostnames }}'
+    --signer-cert='{{ mktemp.stdout }}/certs/ca.crt'
+    --signer-key='{{ mktemp.stdout }}/certs/ca.key'
+    --signer-serial='{{ mktemp.stdout }}/certs/ca.serial.txt'
+- name: generate {{ component }} certificate
+  shell: >
+    cat
+    '{{ mktemp.stdout|quote }}/certs/{{ component|quote }}.key'
+    '{{ mktemp.stdout|quote }}/certs/{{ component|quote }}.crt'
+    > '{{ mktemp.stdout|quote }}/certs/{{ component|quote }}.pem'
+- name: generate random password for the {{ component }} keystore
+  shell: tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c15
+  register: pwd
+- name: create the password file for {{ component }}
+  shell: >
+    echo '{{ pwd.stdout|quote }}'
+    > '{{ mktemp.stdout }}/certs/{{ component|quote }}-keystore.pwd'
+- name: create the {{ component }} pkcs12 from the pem file
+  command: >
+    openssl pkcs12 -export
+    -in '{{ mktemp.stdout }}/certs/{{ component }}.pem'
+    -out '{{ mktemp.stdout }}/certs/{{ component }}.pkcs12'
+    -name '{{ component }}' -noiter -nomaciter
+    -password 'pass:{{ pwd.stdout }}'
+- name: create the {{ component }} keystore from the pkcs12 file
+  command: >
+    keytool -v -importkeystore
+    -srckeystore '{{ mktemp.stdout }}/certs/{{ component }}.pkcs12'
+    -srcstoretype PKCS12
+    -destkeystore '{{ mktemp.stdout }}/certs/{{ component }}.keystore'
+    -deststoretype JKS
+    -deststorepass '{{ pwd.stdout }}'
+    -srcstorepass '{{ pwd.stdout }}'
+- name: create the {{ component }} certificate
+  command: >
+    keytool -noprompt -export
+    -alias '{{ component }}'
+    -file '{{ mktemp.stdout }}/certs/{{ component }}.cert'
+    -keystore '{{ mktemp.stdout }}/certs/{{ component }}.keystore'
+    -storepass '{{ pwd.stdout }}'
+- name: generate random password for the {{ component }} truststore
+  shell: >
+    tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c15
+    > '{{ mktemp.stdout }}/certs/{{ component|quote }}-truststore.pwd'

--- a/roles/openshift_metrics/templates/secret.j2
+++ b/roles/openshift_metrics/templates/secret.j2
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ name }}"
+  labels:
+{% for k, v in labels.iteritems() %}
+    {{ k }}: {{ v }}
+{% endfor %}
+data:
+{% for k, v in data.iteritems() %}
+  {{ k }}: {{ v }}
+{% endfor %}


### PR DESCRIPTION
This deploys the whole metrics stack with non-persistent storage and a single cassandra instance.  Some open questions (see TODO's on the code):
- it's using the original templates on the origin-metrics repository, I'll work on importing them to openshift-ansible next
- the certificate generation `exec`s keytool, I'm not sure what our position is in regard to this, so I just left it that way for now

After running the playbook, waiting for the services to start, configuring the metricsPublicUrl on the master config and restarting, there's even metrics graphs on the web console =)
