### PR TITLE
User provided certs pushed from control. vars reorg

### DIFF
--- a/roles/openshift_metrics/README.md
+++ b/roles/openshift_metrics/README.md
@@ -25,17 +25,17 @@ For default values, see [`defaults/main.yaml`](defaults/main.yaml).
 - `openshift_metrics_image_version`: Specify version for metrics components; e.g. for
   "openshift/origin-metrics-deployer:v1.1", set version "v1.1".
 
-- `openshift_metrics_master_url`: Internal URL for the master, for authentication retrieval.
+- `openshift_metrics_hawkular_cert:` The certificate used for re-encrypting the route
+  to Hawkular metrics.  The certificate must contain the hostname used by the route.
+  The default router certificate will be used if unspecified
 
-- `openshift_metrics_hawkular_user_write_access`: If user accounts should be able to write
-  metrics.  Defaults to 'false' so that only Heapster can write metrics and not
-  individual users.  It is recommended to disable user write access, if enabled
-  any user will be able to write metrics to the system which can affect
-  performance and use Cassandra disk usage to unpredictably increase.
+- `openshift_metrics_hawkular_key:` The key used with the Hawkular certificate
+
+- `openshift_metrics_hawkular_ca:` An optional certificate used to sign the Hawkular certificate.
 
 - `openshift_metrics_hawkular_replicas:` The number of replicas for Hawkular metrics.
 
-- `openshift_metrics_cassandra_nodes`: The number of Cassandra Nodes to deploy for the
+- `openshift_metrics_cassandra_replicas`: The number of Cassandra nodes to deploy for the
   initial cluster.
 
 - `openshift_metrics_cassandra_storage_type`: Use `emptydir` for ephemeral storage (for

--- a/roles/openshift_metrics/defaults/main.yaml
+++ b/roles/openshift_metrics/defaults/main.yaml
@@ -3,22 +3,19 @@ openshift_metrics_start_cluster: True
 openshift_metrics_install_metrics: True
 openshift_metrics_image_prefix: docker.io/openshift/origin-
 openshift_metrics_image_version: latest
-openshift_metrics_master_url: https://kubernetes.default.svc.cluster.local
-openshift_metrics_project: openshift-infra
-openshift_metrics_certs_dir: "{{ openshift.common.config_base }}/master/metrics"
 openshift_metrics_startup_timeout: 500
-openshift_metrics_certs_dir: "{{ openshift.common.config_base }}/master/metrics"
 
-openshift_metrics_hawkular_user_write_access: False
 openshift_metrics_hawkular_replicas: 1
 openshift_metrics_hawkular_limits_memory: 2.5G
 openshift_metrics_hawkular_limits_cpu: null
 openshift_metrics_hawkular_requests_memory: 1.5G
 openshift_metrics_hawkular_requests_cpu: null
+openshift_metrics_hawkular_cert: ""
+openshift_metrics_hawkular_key: ""
+openshift_metrics_hawkular_ca: ""
 
-openshift_metrics_cassandra_nodes: 1
+openshift_metrics_cassandra_replicas: 1
 openshift_metrics_cassandra_storage_type: emptydir
-openshift_metrics_cassandra_pv_prefix: metrics-cassandra
 openshift_metrics_cassandra_pv_size: 10Gi
 openshift_metrics_cassandra_limits_memory: 2G
 openshift_metrics_cassandra_limits_cpu: null
@@ -26,7 +23,6 @@ openshift_metrics_cassandra_requests_memory: 1G
 openshift_metrics_cassandra_requests_cpu: null
 
 openshift_metrics_heapster_standalone: False
-openshift_metrics_heapster_allowed_users: system:master-proxy
 openshift_metrics_heapster_limits_memory: 3.75G
 openshift_metrics_heapster_limits_cpu: null
 openshift_metrics_heapster_requests_memory: 0.9375G
@@ -34,4 +30,19 @@ openshift_metrics_heapster_requests_cpu: null
 
 openshift_metrics_duration: 7
 openshift_metrics_resolution: 15s
+
+#####
+# Caution should be taken for the following defaults before
+# overriding the values here
+#####
+
+openshift_metrics_certs_dir: "{{ openshift.common.config_base }}/master/metrics"
+openshift_metrics_master_url: https://kubernetes.default.svc.cluster.local
 openshift_metrics_node_id: nodename
+openshift_metrics_project: openshift-infra
+
+openshift_metrics_cassandra_pv_prefix: metrics-cassandra
+
+openshift_metrics_hawkular_user_write_access: False
+
+openshift_metrics_heapster_allowed_users: system:master-proxy

--- a/roles/openshift_metrics/tasks/generate_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_certificates.yaml
@@ -4,6 +4,7 @@
     path: "{{ openshift_metrics_certs_dir }}"
     state: directory
     mode: 0700
+
 - name: list existing secrets
   command: >
     {{ openshift.common.client_binary }} -n {{ openshift_metrics_project }}
@@ -11,6 +12,7 @@
     get secrets -o name
   register: metrics_secrets
   changed_when: false
+
 - name: generate ca certificate chain
   shell: >
     {{ openshift.common.admin_binary }} ca create-signer-cert

--- a/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
+++ b/roles/openshift_metrics/tasks/generate_hawkular_certificates.yaml
@@ -3,7 +3,7 @@
   include: setup_certificate.yaml
   vars:
     component: hawkular-metrics
-    hostnames: "hawkular-metrics,{{ openshift_metrics_hawkular_metrics_hostname }}"
+    hostnames: "hawkular-metrics,{{ openshift_metrics_hawkular_hostname }}"
 - name: generate hawkular-cassandra certificates
   include: setup_certificate.yaml
   vars:

--- a/roles/openshift_metrics/tasks/install_hawkular.yaml
+++ b/roles/openshift_metrics/tasks/install_hawkular.yaml
@@ -11,7 +11,7 @@
   vars:
     node: "{{ item }}"
     master: "{{ (item == '1')|string|lower }}"
-  with_sequence: count={{ openshift_metrics_cassandra_nodes }}
+  with_sequence: count={{ openshift_metrics_cassandra_replicas }}
 
 - name: generate hawkular-cassandra persistent volume claims
   template:
@@ -24,7 +24,7 @@
     access_modes:
     - ReadWriteOnce
     size: "{{ openshift_metrics_cassandra_pv_size }}"
-  with_sequence: count={{ openshift_metrics_cassandra_nodes }}
+  with_sequence: count={{ openshift_metrics_cassandra_replicas }}
   when: openshift_metrics_cassandra_storage_type == 'pv'
 
 - name: generate hawkular-cassandra persistent volume claims (dynamic)
@@ -40,25 +40,38 @@
     access_modes:
     - ReadWriteOnce
     size: "{{ openshift_metrics_cassandra_pv_size }}"
-  with_sequence: count={{ openshift_metrics_cassandra_nodes }}
+  with_sequence: count={{ openshift_metrics_cassandra_replicas }}
   when: openshift_metrics_cassandra_storage_type == 'dynamic'
 
 - name: read hawkular-metrics route destination ca certificate
   slurp: src={{ openshift_metrics_certs_dir }}/ca.crt
   register: metrics_route_dest_ca_cert
 
-- name: generate the hawkular-metrics route
-  template:
-    src: route.j2
-    dest: "{{ mktemp.stdout }}/templates/hawkular-metrics-route.yaml"
-  vars:
-    name: hawkular-metrics
-    labels:
-      metrics-infra: hawkular-metrics
-    host: "{{ openshift_metrics_hawkular_metrics_hostname }}"
-    to:
-      kind: Service
+- block:
+  - set_fact: hawkular_key={{ lookup('file', openshift_metrics_hawkular_key) }}
+    when: openshift_metrics_hawkular_key | exists
+
+  - set_fact: hawkular_cert={{ lookup('file', openshift_metrics_hawkular_cert) }}
+    when: openshift_metrics_hawkular_cert | exists
+
+  - set_fact: hawkular_ca={{ lookup('file', openshift_metrics_hawkular_ca) }}
+    when: openshift_metrics_hawkular_ca | exists
+
+  - name: generate the hawkular-metrics route
+    template:
+      src: route.j2
+      dest: "{{ mktemp.stdout }}/templates/hawkular-metrics-route.yaml"
+    vars:
       name: hawkular-metrics
-    tls:
-      termination: reencrypt
-      destination_ca_certificate: "{{ metrics_route_dest_ca_cert.content }}"
+      labels:
+        metrics-infra: hawkular-metrics
+      host: "{{ openshift_metrics_hawkular_hostname }}"
+      to:
+        kind: Service
+        name: hawkular-metrics
+      tls:
+        termination: reencrypt
+        key: "{{ hawkular_key | default('') }}"
+        certificate: "{{ hawkular_cert | default('') }}"
+        ca_certificate: "{{ hawkular_ca | default('') }}"
+        destination_ca_certificate: "{{ metrics_route_dest_ca_cert.content | b64decode }}"

--- a/roles/openshift_metrics/tasks/install_metrics.yaml
+++ b/roles/openshift_metrics/tasks/install_metrics.yaml
@@ -1,7 +1,7 @@
 ---
 - name: check that hawkular_metrics_hostname is set
-  fail: msg='the openshift_metrics_hawkular_metrics_hostname variable is required'
-  when: openshift_metrics_hawkular_metrics_hostname is not defined
+  fail: msg='the openshift_metrics_hawkular_hostname variable is required'
+  when: openshift_metrics_hawkular_hostname is not defined
 
 - name: check the value of openshift_metrics_cassandra_storage_type
   fail:

--- a/roles/openshift_metrics/templates/route.j2
+++ b/roles/openshift_metrics/templates/route.j2
@@ -16,6 +16,18 @@ spec:
 {% if tls is defined %}
   tls:
     termination: {{ tls.termination }}
+{% if tls.ca_certificate is defined and tls.ca_certificate | length > 0 %}
+    CACertificate: |
+{{ tls.ca_certificate|indent(6, true) }}
+{% endif %}
+{% if tls.key is defined and tls.key | length > 0 %}
+    key: |
+{{ tls.key|indent(6, true) }}
+{% endif %}
+{% if tls.certificate is defined and tls.certificate | length > 0 %}
+    certificate: |
+{{ tls.certificate|indent(6, true) }}
+{% endif %}
 {% if tls.termination == 'reencrypt' %}
     destinationCACertificate: |
 {{ tls.destination_ca_certificate|indent(6, true) }}

--- a/roles/openshift_metrics/vars/main.yaml
+++ b/roles/openshift_metrics/vars/main.yaml
@@ -1,3 +1,9 @@
+---
+#
+# These vars are generally considered private and not expected to be altered
+# by end users
+#
+
 openshift_metrics_cassandra_storage_types:
 - emptydir
 - pv


### PR DESCRIPTION
This PR

* reorgs defaults/vars into private/public concept per comments from @sdodson
* allows users to provide external facing certs for hawkular without needing to push them to the target

cc @mwringe @bbguimaraes